### PR TITLE
Remove base16-shell and base16-fzf external dependencies

### DIFF
--- a/home/.chezmoiexternal.toml.tmpl
+++ b/home/.chezmoiexternal.toml.tmpl
@@ -1,15 +1,3 @@
-[".config/base16-shell"]
-  type = "archive"
-  url = "https://github.com/chriskempson/base16-shell/archive/master.tar.gz"
-  exact = true
-  stripComponents = 1
-  refreshPeriod = "168h"
-[".config/base16-fzf"]
-  type = "archive"
-  url = "https://github.com/fnune/base16-fzf/archive/refs/heads/master.zip"
-  exact = true
-  stripComponents = 1
-  refreshPeriod = "168h"
 [".dir_colors"]
   type = "file"
   url = "https://raw.githubusercontent.com/arcticicestudio/nord-dircolors/develop/src/dir_colors"

--- a/home/dot_config/fish/config.fish
+++ b/home/dot_config/fish/config.fish
@@ -4,13 +4,6 @@ fish_add_path ~/.local/bin
 fish_add_path "./bin"
 fish_add_path "$HOME/github/gh-helper-cli/exe"
 
-# base-16
-#if status --is-interactive
-#   source $HOME/.config/base16-shell/profile_helper.fish
-#   base16-nord
-#end
-
-
 set -x -g PROJECTS "$HOME/code"
 
 for i in ~/.config/fish/custom_functions/*.fish
@@ -22,7 +15,11 @@ if type -q fzf and type -q rg
     set -x FZF_CTRL_T_COMMAND $$FZF_DEFAULT_COMMAND
     set -x FZF_ALT_C_COMMAND $FZF_DEFAULT_COMMAND
 
-    source ~/.config/base16-fzf/fish/base16-nord.fish
+    # Nord color scheme for fzf (base16-nord palette)
+    set -Ux FZF_DEFAULT_OPTS \
+        "--color=bg+:#3b4252,bg:#2e3440,spinner:#88c0d0,hl:#81a1c1" \
+        "--color=fg:#d8dee9,header:#81a1c1,info:#ebcb8b,pointer:#88c0d0" \
+        "--color=marker:#88c0d0,fg+:#eceff4,prompt:#ebcb8b,hl+:#81a1c1"
 end
 
 # command -v vg >/dev/null 2>&1; and vg eval --shell fish | source

--- a/home/symlink_dot_base16_theme
+++ b/home/symlink_dot_base16_theme
@@ -1,1 +1,0 @@
-/Users/cjs/.config/base16-shell/scripts/base16-nord.sh


### PR DESCRIPTION
## Summary

Removes two third-party external dependencies identified as supply chain risks in a security audit.

### What was removed

- **`chriskempson/base16-shell`** — The original author deleted their GitHub account; the repo was transferred to a third party. The fish integration (`profile_helper.fish`) was already commented out and inactive. The `~/.base16_theme` symlink it managed was broken.
- **`fnune/base16-fzf`** — Individual-maintained repo, fetched from `master` weekly. The only use was sourcing a single static file of Nord color hex values for FZF.

### What replaces them

The 4 lines of Nord FZF color config previously sourced from `base16-fzf` are now inlined directly in `config.fish`. The colors are identical — they were hardcoded to Nord already.

### Files changed

| File | Change |
|---|---|
| `home/.chezmoiexternal.toml.tmpl` | Removed both `base16-shell` and `base16-fzf` archive entries |
| `home/dot_config/fish/config.fish` | Replaced `source ~/.config/base16-fzf/fish/base16-nord.fish` with inline Nord hex values; removed commented-out `base16-shell` block |
| `home/symlink_dot_base16_theme` | Deleted (pointed at now-removed base16-shell scripts dir) |